### PR TITLE
Don't symlink tmux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -228,10 +228,13 @@ tmux_install(){
 
 if check_tmux_version bin/tmux; then
   echo ':Existing tmux version is up-to-date'
-elif has "tmux" && check_tmux_version tmux; then
-  echo ':A good version of tmux was found, creating a symlink'
-  ln -sf $(which tmux) "$C9_DIR"/bin/tmux
-  return 0
+
+# If we can support tmux 1.9 or detect upgrades, the following would work:
+#elif has "tmux" && check_tmux_version tmux; then
+#  echo ':A good version of tmux was found, creating a symlink'
+#  ln -sf $(which tmux) "$C9_DIR"/bin/tmux
+#  return 0
+
 # If tmux is not present or at the wrong version, we will install it
 else
   if [ $os = "darwin" ]; then


### PR DESCRIPTION
@mastrolinux Since we don't support tmux 1.9, but only versions <1.9, we shouldn't use the symlinking approach.
