### PR TITLE
arm7l support to c9 installer script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@ else
 fi
 
 VERSION=1
-NODE_VERSION=v0.10.28
+NODE_VERSION=v0.10.3
 C9_DIR=$HOME/.c9
 NPM=$C9_DIR/node/bin/npm
 NODE=$C9_DIR/node/bin/node
@@ -52,6 +52,7 @@ start() {
     *x86_64*) arch=x64 ;;
     *i*86*) arch=x86 ;;
     *armv6l*) arch=arm-pi ;;
+    *armv7l*) arch=arm-pi ;;
   esac
   
   if [ $os != "linux" ] && [ $os != "darwin" ]; then
@@ -59,7 +60,7 @@ start() {
     exit 1
   fi
   
-  if [ $arch != "x64" ] && [ $arch != "x86" ]; then
+  if [ $arch != "x64" ] && [ $arch != "x86" ] && [ $arch != "arm-pi" ]; then
     echo "Unsupported Architecture: $os $arch" 1>&2
     exit 1
   fi


### PR DESCRIPTION
NOTE!
arm-pi build of node 0.10.28 does not exist, changed to later version 0.10.3 which contains a arm build.

http://nodejs.org/dist/v0.10.3/

http://nodejs.org/dist/v0.10.28/

Tested on BeagleBone Black
