### PR TITLE
Support 1.9a as version number for tmux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -232,7 +232,7 @@ check_tmux_version(){
   if [ ! -x $1 ]; then
     return 1
   fi
-  tmux_version=$($1 -V | cut -d' ' -f2)  
+  tmux_version=$($1 -V | sed -e's/[a-z ]//g')  
   if [ ! "$tmux_version" ]; then
     return 1
   fi


### PR DESCRIPTION
Let's just ignore 'a' as version postfix, by stripping anything alpha and whitespace from the tmux version.

This fixes install.sh on the mac, where brew has tmux 1.9a.
