### PR TITLE
Fix node-gyp problem by removing global gyp from path through virtualenv.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -71,8 +71,9 @@ start() {
   fi
   
   if [ `python -c 'import gyp; print gyp.__file__' 2> /dev/null` ]; then
-  	echo "You have a global gyp installed. Please run 'sudo apt-get remove gyp'"
-  	exit 100
+    echo "You have a global gyp installed. Setting up VirtualEnv without global pakages"
+    virtualenv $C9_DIR/python
+    npm config set python $C9_DIR/python/bin/python2
   fi
   
   case $1 in
@@ -137,7 +138,7 @@ start() {
       done
       popd
       
-      echo $VERSION > $HOME/.c9/installed
+      echo $VERSION > $C9_DIR/installed
       echo :Done.
     ;;
     


### PR DESCRIPTION
This allows you to install c9sdk even if you are not root (as long as virtualenv is installed).

I don't properly check for virtualenv being installed, but I wanted to make sure that this is something desired by the project first.

Licensed under MIT, as with the original install script.