### PR TITLE
GPG verify node, add path to our node/npm

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -195,8 +195,7 @@ node(){
   gpg --list-keys 114F43EE0176B71C7BC219DD50A3051F888C628D 2>&1 >/dev/null || gpg --keyserver pool.sks-keyservers.net --recv-keys 114F43EE0176B71C7BC219DD50A3051F888C628D
   $DOWNLOAD http://nodejs.org/dist/$NODE_VERSION/SHASUMS256.txt.asc
   $DOWNLOAD http://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-$1-$2.tar.gz
-  gpg --verify SHASUMS256.txt.asc
-  grep " node-$NODE_VERSION-$1-$2.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - || exit 1
+  gpg --verify SHASUMS256.txt.asc && grep " node-$NODE_VERSION-$1-$2.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - || exit 1
 
   tar xvfz node-$NODE_VERSION-$1-$2.tar.gz
   mv node-$NODE_VERSION-$1-$2 node


### PR DESCRIPTION
Set npm config lower by checking for python in c9 dir.  $NPM doesn't exist where it was previously being set.

Add local node to path so that node-gyp doesn't use the system wide one or complain about 'command not found'.  I add this at the point where we install node, so that we can use that node everywhere, in cases where people don't have any node installed.

This branch successfully builds the SDK using my docker file:
https://github.com/ClashTheBunny/c9-3-dockerfile

So it should work on standard installs of Ubuntu.