### PR TITLE
Add lsof (used by the gdbdebugger plugin) as a dependency

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -176,6 +176,16 @@ check_deps() {
       ERR=1
     fi
   done
+
+  # lsof
+  if ! has "lsof"; then
+      echo "Error: please install lsof to proceed" >&2
+      if [ "$OS" == "CentOS" ]; then
+        echo "To do so, log into your machine and type 'yum install -y lsof'" >&2
+      elif [ "$OS" == "DEBIAN" ]; then
+        echo "To do so, log into your machine and type 'sudo apt-get install lsof'" >&2
+      fi
+  fi
   
   # CentOS
   if [ "$OS" == "CentOS" ]; then


### PR DESCRIPTION
The gdbdebugger plugin implementation uses lsof and greps for gdbserver to
see if it has started, and keeps looping until it does.

On a standard arch linux box, lsof is not installed by default, and this
causes the plugin to assume gdbserver hasn't spun up - it ends up looping
endlessly. Takes some time and debugging effort to figure out the actual problem.