### PR TITLE
Changed check of /etc/issue to /etc/os-release

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -159,7 +159,7 @@ check_deps() {
   local ERR
   local OS
   
-  if [[ `cat /etc/issue 2>/dev/null` =~ CentOS ]]; then
+  if [[ `cat /etc/os-release 2>/dev/null` =~ CentOS ]]; then
     OS="CentOS"
   elif [[ `cat /proc/version 2>/dev/null` =~ Ubuntu|Debian ]]; then
     OS="DEBIAN"


### PR DESCRIPTION
cat of /etc/issue doesn't yield distribution like /etc/os-release does.
Thus the installer for CentOS machines will not work.

[root@aadt1 etc]# cat issue 
\S
Kernel \r on an \m

[root@aadt1 etc]# cat os-release 
NAME="CentOS Linux"
VERSION="7 (Core)"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="7"
PRETTY_NAME="CentOS Linux 7 (Core)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:7"
HOME_URL="https://www.centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"

CENTOS_MANTISBT_PROJECT="CentOS-7"
CENTOS_MANTISBT_PROJECT_VERSION="7"
REDHAT_SUPPORT_PRODUCT="centos"
REDHAT_SUPPORT_PRODUCT_VERSION="7"