### PR TITLE
update node and use prebuilt pty.js

### DIFF
--- a/packages/release.sh
+++ b/packages/release.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -e
+set -ex
+
+cd `dirname $0`
+SOURCE=`pwd`
+
+buildPtyRelease() {
+  if [ "`"$C9_DIR/node/bin/node" -v`" != "$NODE_VERSION" ] ; then
+    exit 1
+  fi
+  cd "$C9_DIR"
+  buildPty
+  pushd node_modules/pty.js/
+  rm -rf tmp
+  mkdir -p tmp
+  cp build/Release/pty.node tmp/pty.node
+  rm -rf build
+  
+  mkdir -p build/Release
+  cp tmp/* build/Release
+  rm -rf tmp deps node_modules/nan test
+  if hasPty; then
+    cd ..
+    local target="$SOURCE/pty.js/pty-$NODE_VERSION-$os-$arch.tar.gz"
+    rm -f "$target"
+    tar -zcvf "$target" pty.js
+  fi
+  popd
+}
+
+. ../install.sh install buildPtyRelease


### PR DESCRIPTION
This fixes installation for centos6

but may cause trouble for people using 32 bit linux, since new versions of sqlite3 do not provide prebuilt binaries for it https://github.com/mapbox/node-sqlite3/blob/master/CHANGELOG.md#310