### PR TITLE
Don't disable certificate checking in wget

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@ exec 2>&1
 
 if has "wget"; then
   DOWNLOAD() {
-    wget --no-check-certificate -nc -O "$2" "$1"
+    wget -nc -O "$2" "$1"
   }
 elif has "curl"; then
   DOWNLOAD() {


### PR DESCRIPTION
While cert errors are annoying, it's better to fix them than be MITMed.