### PR TITLE
Remove redundant command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,6 @@
 set -e
 has() {
   type "$1" > /dev/null 2>&1
-  return $?
 }
 
 # Redirect stdout ( > ) into a named pipe ( >() ) running "tee"


### PR DESCRIPTION
This `return` command is mimicking the default shell behavior: to return the exit code for the last executed command (in this case, the `type` command).

In other words: this line is redundant, can be safely removed.