### PR TITLE
sqlite3@3.1.9 breaks on installation, use 3.1.8

### DIFF
--- a/link.sh
+++ b/link.sh
@@ -52,7 +52,7 @@ popd
 # install required node modules
 mkdir -p node_modules
 npm i pty.js
-npm i sqlite3 sequelize@2.0.0-beta.0
+npm i sqlite3@3.1.8 sequelize@2.0.0-beta.0
 
 npm i https://github.com/c9/nak/tarball/c9
 


### PR DESCRIPTION
As the titles says..
Reference: https://github.com/mapbox/node-sqlite3/issues/865