### PR TITLE
Install NodeJS v4.8.7

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,7 @@ else
 fi
 
 VERSION=1
-NODE_VERSION=v4.4.6
+NODE_VERSION=v4.8.7
 C9_DIR=$HOME/.c9
 NPM=$C9_DIR/node/bin/npm
 NODE=$C9_DIR/node/bin/node


### PR DESCRIPTION
AWS SAM Local has a dependency that throws a warning if using Node < 4.5 which is confusing some users setting up AWS Cloud9 SSH workspaces. The AWS Cloud9 installer already installs NodeJS 4.8.7 so updating this package to be consistent.