### PR TITLE
Bring back -d option

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -22,12 +22,10 @@ else
 fi
 
 C9_DIR=$HOME/.c9
-while [ $# -gt 0 ]; do
-  case "$1" in
-    -d | --dest-dir ) C9_DIR="$2"; shift;;
-  esac
-  shift
-done
+if [[ ${1-} == -d ]]; then
+    C9_DIR=$2
+    shift 2
+fi
 
 # Check if C9_DIR exists
 if [ ! -d "$C9_DIR" ]; then

--- a/install.sh
+++ b/install.sh
@@ -22,6 +22,13 @@ else
 fi
 
 C9_DIR=$HOME/.c9
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -d | --dest-dir ) C9_DIR="$2"; shift;;
+  esac
+  shift
+done
+
 # Check if C9_DIR exists
 if [ ! -d "$C9_DIR" ]; then
   mkdir -p $C9_DIR


### PR DESCRIPTION
The AMI builder uses the -d option. This change brings back that option, although it breaks the other options. We don't use the other options, so this is better for now.