### PR TITLE
Update install.sh to include PowerPC 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -77,6 +77,8 @@ start() {
     *armv7l*) arch=armv7l ;;
     *x86_64*) arch=x64 ;;
     *i*86*) arch=x86 ;;
+    *ppc64le*) arch=ppc64le ;;
+    *ppc64*) arch=ppc64 ;;
     *)
       echo "Unsupported Architecture: $os $arch" 1>&2
       exit 1


### PR DESCRIPTION
unable to use the install script with ppc64

added entries so that it can be used for both ppc64 and ppc64le (big endian and little endian respectively)

tested ppc64 on a Power7

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
