### PR TITLE
Update documentation links

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -218,7 +218,7 @@ check_python() {
   fi
 
   if [[ $PYTHONVERSION != "2.7" ]]; then
-    echo "Python version 2.7 is required to install pty.js. Please install python 2.7 and try again. You can find more information on how to install Python in the docs: https://docs.c9.io/ssh_workspaces.html"
+    echo "Python version 2.7 is required to install pty.js. Please install python 2.7 and try again. You can find more information on how to install Python in the docs: https://docs.aws.amazon.com/cloud9/latest/user-guide/ssh-settings.html#ssh-settings-requirements"
     exit 100
   fi
 }


### PR DESCRIPTION
`https://docs.c9.io/ssh_workspaces.html` no longer points to a correct location. The new link has instructions regarding python installation. There are no other instances of old doc links in this package.